### PR TITLE
Add `X-Forwarded-For` and `X-Forwarded-Proto` headers to request

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Features
 * Copy all http headers sent from the proxied server to the client (except `hop-by-hop <http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.1>`_)
 * Basic URL rewrite
 * Sets the http header REQUEST_USER if the user is logged in Django
+* Sets the http headers X-Forwarded-For and X-Forwarded-Proto
 * Handles redirects
 * Few external dependencies
 * Apply XSLT transformation in the response (requires Diazo)

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -16,6 +16,8 @@ At a high level, this is what happens behind the scenes in a request proxied by 
 
 #. If the user is authenticated in Django and `add_remote_user` attribute is set to `True` the HTTP header `REMOTE_USER` will be set with `request.user.username`.
 
+#. If the `add_x_forwarded` attribute is set to `True` the HTTP headers `X-Forwarded-For` and `X-Forwarded-Proto` will be set to the IP address of the requestor and the protocol (http or https), respectively.
+
 #. The cloned request is sent to the upstream server (set in the view).
 
 #. After receiving the response from upstream, the view will process it to make sure all headers are set properly. Some headers like `Location` are treated as special cases.

--- a/docs/proxyview.rst
+++ b/docs/proxyview.rst
@@ -37,6 +37,11 @@ This document covers the views provided by ``revproxy.views`` and all it's publi
         Whether to add the ``REMOTE_USER`` to the request in case of an
         authenticated user. Defaults to ``False``.
 
+    .. attribute:: add_x_forwarded
+
+        Whether to add the ``X-Forwarded-For`` and ``X-Forwarded-Proto``
+        headers to the request. Defaults to ``False``.
+
     .. attribute:: default_content_type
 
         The *Content-Type* that will be added to the response in case

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -155,9 +155,10 @@ class ViewTest(TestCase):
         proxy_view = DiazoProxyView()
         self.assertFalse(proxy_view.html5)
 
-    def test_default_add_remote_user_attr(self):
+    def test_default_attributes(self):
         proxy_view = DiazoProxyView()
         self.assertFalse(proxy_view.add_remote_user)
+        self.assertFalse(proxy_view.add_x_forwarded)
 
     def test_inheritance_context_mixin(self):
         mixin_view = DiazoProxyView()


### PR DESCRIPTION
Closes #79

To remain backwards compatible, I decided to make it possible to enable with setting `add_x_forwarded` on the view.
`X-Forwarded-For` and `X-Forwarded-Proto` headers are required to be passed in by a lot of software that works with reverse proxies, including Keycloak for example.