### PR TITLE
update request.is_ajax()

### DIFF
--- a/revproxy/transformer.py
+++ b/revproxy/transformer.py
@@ -81,7 +81,7 @@ class DiazoTransformer(object):
             self.log.info("DIAZO_OFF_RESPONSE_HEADER in response.get: off")
             return False
 
-        if self.request.is_ajax():
+        if self.request.headers.get('x-requested-with') == 'XMLHttpRequest':
             self.log.info("Request is AJAX")
             return False
 


### PR DESCRIPTION
request.is_ajax() got deprecated in Django3.2