### PR TITLE
Make `streaming_amount` configurable via View class attribute

### DIFF
--- a/docs/proxyview.rst
+++ b/docs/proxyview.rst
@@ -82,6 +82,12 @@ This document covers the views provided by ``revproxy.views`` and all it's publi
         any cookies received from the upstream server that do not conform to
         the RFC will be dropped.
 
+    .. attribute:: streaming_amount
+
+        The buffering amount for streaming HTTP response(in bytes), response will
+        be buffered until it's length exceeds this value. ``None`` means using
+        default value, override this variable to change.
+
     **Methods**
 
     .. automethod:: revproxy.views.ProxyView.get_request_headers

--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -36,7 +36,7 @@ def get_django_response(
     logger.debug('Content-Type: %s', content_type)
 
     if should_stream(proxy_response):
-        amt = get_streaming_amt(proxy_response)
+        amt = get_streaming_amt(proxy_response) if streaming_amount is None else streaming_amount
         logger.info(('Starting streaming HTTP Response, buffering amount='
                      '"%s bytes"'), amt)
         response = StreamingHttpResponse(proxy_response.stream(amt),

--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -4,13 +4,12 @@ from .utils import cookie_from_string, should_stream, set_response_headers
 
 from django.http import HttpResponse, StreamingHttpResponse
 
-#: Default number of bytes that are going to be read in a file lecture
-DEFAULT_AMT = 2 ** 16
-
 logger = logging.getLogger('revproxy.response')
 
 
-def get_django_response(proxy_response, strict_cookies=False):
+def get_django_response(
+    proxy_response, strict_cookies=False, streaming_amount=None
+):
     """This method is used to create an appropriate response based on the
     Content-Length of the proxy_response. If the content is bigger than
     MIN_STREAMING_LENGTH, which is found on utils.py,
@@ -20,6 +19,10 @@ def get_django_response(proxy_response, strict_cookies=False):
     :param proxy_response: An Instance of urllib3.response.HTTPResponse that
                            will create an appropriate response
     :param strict_cookies: Whether to only accept RFC-compliant cookies
+    :param streaming_amount: The amount for streaming HTTP response, if not
+                             given, use a dynamic value -- 1("no-buffering")
+                             for "text/event-stream" content type, 65535 for
+                             other types.
     :returns: Returns an appropriate response based on the proxy_response
               content-length
     """
@@ -33,8 +36,10 @@ def get_django_response(proxy_response, strict_cookies=False):
     logger.debug('Content-Type: %s', content_type)
 
     if should_stream(proxy_response):
-        logger.info('Content-Length is bigger than %s', DEFAULT_AMT)
-        response = StreamingHttpResponse(proxy_response.stream(DEFAULT_AMT),
+        amt = get_streaming_amt(proxy_response)
+        logger.info(('Starting streaming HTTP Response, buffering amount='
+                     '"%s bytes"'), amt)
+        response = StreamingHttpResponse(proxy_response.stream(amt),
                                          status=status,
                                          content_type=content_type)
     else:
@@ -57,3 +62,26 @@ def get_django_response(proxy_response, strict_cookies=False):
     logger.debug('Response cookies: %s', response.cookies)
 
     return response
+
+
+# Default number of bytes that are going to be read in a file lecture
+DEFAULT_AMT = 2**16
+# The amount of chunk being used when no buffering is needed: return every byte
+# eagerly, which might be bad in performance perspective, but is essential for
+# some special content types, e.g. "text/event-stream". Without disabling
+# buffering, all events will pending instead of return in realtime.
+NO_BUFFERING_AMT = 1
+
+NO_BUFFERING_CONTENT_TYPES = set(['text/event-stream', ])
+
+
+def get_streaming_amt(proxy_response):
+    """Get the value of streaming amount(in bytes) when streaming response
+
+    :param proxy_response: urllib3.response.HTTPResponse object
+    """
+    content_type = proxy_response.headers.get('Content-Type', '')
+    # Disable buffering for "text/event-stream"(or other special types)
+    if content_type.lower() in NO_BUFFERING_CONTENT_TYPES:
+        return NO_BUFFERING_AMT
+    return DEFAULT_AMT

--- a/revproxy/response.py
+++ b/revproxy/response.py
@@ -36,7 +36,11 @@ def get_django_response(
     logger.debug('Content-Type: %s', content_type)
 
     if should_stream(proxy_response):
-        amt = get_streaming_amt(proxy_response) if streaming_amount is None else streaming_amount
+        if streaming_amount is None:
+            amt = get_streaming_amt(proxy_response)
+        else:
+            amt = streaming_amount
+
         logger.info(('Starting streaming HTTP Response, buffering amount='
                      '"%s bytes"'), amt)
         response = StreamingHttpResponse(proxy_response.stream(amt),

--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -53,6 +53,11 @@ class ProxyView(View):
     rewrite = tuple()  # It will be overrided by a tuple inside tuple.
     strict_cookies = False
 
+    # The buffering amount for streaming HTTP response(in bytes), response will
+    # be buffered until it's length exceeds this value. `None` means using
+    # default value, override this variable to change.
+    streaming_amount = None
+
     def __init__(self, *args, **kwargs):
         super(ProxyView, self).__init__(*args, **kwargs)
 
@@ -235,7 +240,8 @@ class ProxyView(View):
         self._set_content_type(request, proxy_response)
 
         response = get_django_response(proxy_response,
-                                       strict_cookies=self.strict_cookies)
+                                       strict_cookies=self.strict_cookies,
+                                       streaming_amount=self.streaming_amount)
 
         self.log.debug("RESPONSE RETURNED: %s", response)
         return response

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -10,6 +10,7 @@ from django.test import RequestFactory, TestCase
 from mock import MagicMock, patch
 from urllib3.exceptions import HTTPError
 
+from revproxy.response import get_streaming_amt, DEFAULT_AMT, NO_BUFFERING_AMT
 from .utils import (get_urlopen_mock, DEFAULT_BODY_CONTENT,
                     CustomProxyView, URLOPEN)
 
@@ -171,3 +172,14 @@ class ResponseTest(TestCase):
         else:
             response_headers = response._headers
         self.assertFalse(response.cookies)
+
+
+class TestGetDjangoResponse(TestCase):
+
+    def test_normal(self):
+        resp = urllib3.response.HTTPResponse()
+        self.assertEqual(get_streaming_amt(resp), DEFAULT_AMT)
+
+    def test_event_stream(self):
+        resp = urllib3.response.HTTPResponse(headers={'Content-Type': 'text/event-stream'})
+        self.assertEqual(get_streaming_amt(resp), NO_BUFFERING_AMT)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -174,7 +174,7 @@ class ResponseTest(TestCase):
         self.assertFalse(response.cookies)
 
 
-class TestGetDjangoResponse(TestCase):
+class TestGetStreamingAmt(TestCase):
 
     def test_normal(self):
         resp = urllib3.response.HTTPResponse()


### PR DESCRIPTION
This PR:

- Make `streaming_amount` configurable via View class attribute
- Disable buffering when streaming "text/event-stream" response

More details can be found in code comments.