### PR TITLE
Fixed Header interface for Python 3.10

### DIFF
--- a/revproxy/utils.py
+++ b/revproxy/utils.py
@@ -134,7 +134,7 @@ def set_response_headers(response, response_headers):
     if hasattr(response, 'headers'):
         logger.debug('Response headers: %s', response.headers)
     else:
-        logger.debug('Response headers: %s', getattr(response, '_headers'))
+        logger.debug('Response headers: %s', getattr(response, '_headers', None))
 
 
 def normalize_request_headers(request):


### PR DESCRIPTION
This PR enables this package to be used with Python 3.10 in combination with Django 3.2+.

`getattr()` expects a default value in order for it not to return an exception.

Closes #147.