### PR TITLE
Fix Valid Cookie Attribute List

### DIFF
--- a/revproxy/utils.py
+++ b/revproxy/utils.py
@@ -195,7 +195,7 @@ def cookie_from_string(cookie_string, strict_cookies=False):
 
     else:
         valid_attrs = ('path', 'domain', 'comment', 'expires',
-                       'max_age', 'httponly', 'secure', 'samesite')
+                       'max-age', 'httponly', 'secure', 'samesite')
 
         cookie_dict = {}
 

--- a/revproxy/utils.py
+++ b/revproxy/utils.py
@@ -195,7 +195,7 @@ def cookie_from_string(cookie_string, strict_cookies=False):
 
     else:
         valid_attrs = ('path', 'domain', 'comment', 'expires',
-                       'max_age', 'httponly', 'secure')
+                       'max_age', 'httponly', 'secure', 'samesite')
 
         cookie_dict = {}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,7 +112,7 @@ class UtilsTest(TestCase):
     def test_valid_attr_in_cookie_from_string(self):
         cookie = "_cookie_session=1266bb13c139cfba3ed1c9c68110bae9;" \
                  "expires=Thu, 29 Jan 2015 13:51:41 -0000; httponly;" \
-                 "secure;Path=/gitlab"
+                 "secure;Path=/gitlab;samesite=lax"
 
         self.assertIn('path', utils.cookie_from_string(cookie))
         self.assertIn('/', utils.cookie_from_string(cookie)['path'])
@@ -126,6 +126,9 @@ class UtilsTest(TestCase):
 
         self.assertIn('secure', utils.cookie_from_string(cookie))
         self.assertTrue(utils.cookie_from_string(cookie)['secure'])
+
+        self.assertIn('samesite', utils.cookie_from_string(cookie))
+        self.assertIn('lax', utils.cookie_from_string(cookie)['samesite'])
 
         self.assertIn('value', utils.cookie_from_string(cookie))
         self.assertIn('1266bb13c139cfba3ed1c9c68110bae9',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,7 +112,7 @@ class UtilsTest(TestCase):
     def test_valid_attr_in_cookie_from_string(self):
         cookie = "_cookie_session=1266bb13c139cfba3ed1c9c68110bae9;" \
                  "expires=Thu, 29 Jan 2015 13:51:41 -0000; httponly;" \
-                 "secure;Path=/gitlab;samesite=lax"
+                 "secure;Path=/gitlab;max-age=60;samesite=lax"
 
         self.assertIn('path', utils.cookie_from_string(cookie))
         self.assertIn('/', utils.cookie_from_string(cookie)['path'])
@@ -129,6 +129,9 @@ class UtilsTest(TestCase):
 
         self.assertIn('samesite', utils.cookie_from_string(cookie))
         self.assertIn('lax', utils.cookie_from_string(cookie)['samesite'])
+
+        self.assertIn('max-age', utils.cookie_from_string(cookie))
+        self.assertIn('60', utils.cookie_from_string(cookie)['max-age'])
 
         self.assertIn('value', utils.cookie_from_string(cookie))
         self.assertIn('1266bb13c139cfba3ed1c9c68110bae9',


### PR DESCRIPTION
The list of valid cookie attributes is missing `SameSite`, and the `Max-Age`attribute should be spelled with a hyphen, not an underscore. These errors were causing cookies with these attributes set to be dropped when returned across the proxy:
![image](https://user-images.githubusercontent.com/70175606/178898660-01dc87e4-afd8-4b96-a86a-75620e905838.png)

Reference for attribute names:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie