### PR TITLE
Fix Mismatch in Max-Age Names

### DIFF
--- a/revproxy/utils.py
+++ b/revproxy/utils.py
@@ -230,6 +230,10 @@ def cookie_from_string(cookie_string, strict_cookies=False):
                     # ignoring comment attr as explained in the
                     # function docstring
                     continue
+                elif attr == 'max-age':
+                    # The cookie uses 'max-age' but django's
+                    # set_cookie uses 'max_age'
+                    cookie_dict['max_age'] = unquote(value)
                 else:
                     cookie_dict[attr] = unquote(value)
             else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -130,8 +130,8 @@ class UtilsTest(TestCase):
         self.assertIn('samesite', utils.cookie_from_string(cookie))
         self.assertIn('lax', utils.cookie_from_string(cookie)['samesite'])
 
-        self.assertIn('max-age', utils.cookie_from_string(cookie))
-        self.assertIn('60', utils.cookie_from_string(cookie)['max-age'])
+        self.assertIn('max_age', utils.cookie_from_string(cookie))
+        self.assertIn('60', utils.cookie_from_string(cookie)['max_age'])
 
         self.assertIn('value', utils.cookie_from_string(cookie))
         self.assertIn('1266bb13c139cfba3ed1c9c68110bae9',


### PR DESCRIPTION
Related to #150. The current code assumes that the cookie attributes have the same names as the arguments to the `set_cookie` function, but this isn't the case for `Max-Age` because the argument uses an underscore instead of a hyphen. This PR adds a special case for handling the `Max-Age` attribute.