### PR TITLE
Update python and django versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/revproxy/transformer.py
+++ b/revproxy/transformer.py
@@ -63,6 +63,17 @@ class DiazoTransformer(object):
         self.log = logging.getLogger('revproxy.transformer')
         self.log.info("DiazoTransformer created")
 
+    def is_ajax(self):
+        """
+        request.is_ajax() is marked as deprecated in django 3.1. removed in 4.0
+        See: https://docs.djangoproject.com/en/3.1/releases/3.1/#id2
+        """
+        if hasattr(self.request, 'is_ajax'):
+            return self.request.is_ajax()
+        else:
+            return self.request.headers.get('x-requested-with') \
+                   == 'XMLHttpRequest'
+
     def should_transform(self):
         """Determine if we should transform the response
 
@@ -81,7 +92,7 @@ class DiazoTransformer(object):
             self.log.info("DIAZO_OFF_RESPONSE_HEADER in response.get: off")
             return False
 
-        if self.request.is_ajax():
+        if self.is_ajax():
             self.log.info("Request is AJAX")
             return False
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-
 import codecs
 import os
 import re
@@ -27,7 +26,7 @@ setup(
     long_description=read('README.rst'),
     packages=['revproxy'],
     install_requires=[
-        'django>=1.7',
+        'django>=3.0',
         'urllib3>=1.12',
     ],
     extras_require={
@@ -47,15 +46,15 @@ setup(
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: Proxy Servers',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries',
-        ],
+    ],
 )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,7 @@
-from django.conf.urls import url
-try:
-    from django.contrib.auth.views import login
-except ImportError:
-    # Django 2.2 moved this
-    from django.contrib.auth import login
+from django.urls import path
+
+from django.contrib.auth import login
 
 urlpatterns = [
-    url(r'^accounts/login/$', login, name='login'),
+    path('accounts/login/', login, name='login'),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 DJANGO =
@@ -21,35 +22,30 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    py{27,35,36,37}-dj{18,19,110,111}
-    py{35,36,37,38}-dj{22}
-    py{36,37,38,39}-dj{30}
+    py{37,38,39}-dj{30}
     py{36,37,38,39}-dj{31}
     py{36,37,38,39,310}-dj{32}
+    py{38,39,310,311}-dj{40}
+    py{38,39,310,311}-dj{41}
 
 [testenv]
 basepython =
-    py27: python2.7
-    py35: python3.5
-    py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
 
 deps =
     coverage
     flake8
-    dj18: Django>=1.8,<1.8.99
-    dj19: Django>=1.9,<1.9.99
-    dj110: Django>=1.10,<1.10.99
-    dj111: Django>=1.11,<1.11.99
-    dj22: Django>=2.2,<2.2.99
     dj30: Django>=3.0,<3.0.99
     dj31: Django>=3.1,<3.1.99
     dj32: Django>=3.2,<3.2.99
+    dj40: Django>=4.0,<4.0.99
+    dj41: Django>=4.1,<4.1.99
 
 commands =
     flake8 revproxy -v
     coverage run --branch --source=revproxy setup.py test
-    coverage report --fail-under=80 --show-missing
+    coverage report --fail-under=90 --show-missing


### PR DESCRIPTION
**Dropped**
  - Drop support for python 2.7, 3.5 and 3.6. 
  - Drop support for django 1.x and 2.x.

**Added**
  - Add Support for python 3.11
  - Added support for django 4.0 and 4.1

**Changes**
- Added `is_ajax` method to `DiazoTransformer` as it was deprecated from request object.
- Replaced old django url in favor of path.