### PR TITLE
Fixed sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,7 +109,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
 sphinx==7.2.6
+sphinx_rtd_theme==1.3.0
+readthedocs-sphinx-search==0.3.1


### PR DESCRIPTION
In #177, readthedocs theme changed. This PR fixes that.

Before this PR:
<img width="1075" alt="Captura de pantalla 2023-11-27 a las 0 50 52" src="https://github.com/jazzband/django-revproxy/assets/5434104/55a117e4-d3b0-4afb-b03d-b6c022a1d9f8">

After this PR:
<img width="1124" alt="Captura de pantalla 2023-11-27 a las 0 51 03" src="https://github.com/jazzband/django-revproxy/assets/5434104/cb62bea2-53c9-4858-a18b-f6d282fd9371">
