### PR TITLE
Replaced deprecated getheader in favor of headers

### DIFF
--- a/revproxy/views.py
+++ b/revproxy/views.py
@@ -198,7 +198,7 @@ class ProxyView(View):
                                                decode_content=False,
                                                preload_content=False)
             self.log.debug("Proxy response header: %s",
-                           proxy_response.getheaders())
+                           proxy_response.headers)
         except urllib3.exceptions.HTTPError as error:
             self.log.exception(error)
             raise


### PR DESCRIPTION
May fix #183 deprecation warning. urrlib3 `response.headers` property is available in all versions supported by django-revproxy.