### PR TITLE
Enforce Ubuntu 22.04 in pipelines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     if: github.repository == 'jazzband/django-revproxy'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']


### PR DESCRIPTION
# Summary

Python 3.7 is not available anymore in `ubuntu-latest` image. Here it is the output of a failing test pipeline.
```
Run actions/setup-python@v4
  with:
    python-version: 3.7
    cache: pip
    cache-dependency-path: pyproject.toml
    check-latest: false
    token: ***
    update-environment: true
    allow-prereleases: false
Installed versions
  Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu [2](https://github.com/jazzband/django-revproxy/actions/runs/13422519281/job/37498296312#step:3:2)4.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

See https://github.com/actions/setup-python/issues/962#issuecomment-2414418045 for further information.